### PR TITLE
判断文件类型时，不是文件夹就应该是文件，filetype属性已经变成扩展名了

### DIFF
--- a/src/360Exporter.user.js
+++ b/src/360Exporter.user.js
@@ -175,7 +175,7 @@ var Ex = {
                                 f.fileName = f.oriName;
                                 if (f.isDir == 1) {
                                     _this.getFolderList(array[i]);
-                                } else if (f.fileType == 'file') {
+                                } else /* if (f.fileType == 'file') */ {
                                     _this.getFile(f);
                                 }
                             }


### PR DESCRIPTION
jpg文件的时候filetype的值是jpg，而不是file,其他的没具体试，下载文件夹的时候会有这个影响。